### PR TITLE
Typo fix? ScreenshotMethods --> ScreeenshotMethod

### DIFF
--- a/ZombieBot/ZombieBot/Program.cs
+++ b/ZombieBot/ZombieBot/Program.cs
@@ -89,7 +89,7 @@ namespace ZombieBot
             string region = "us"; // Default region for the Abyxa server.
             bool local = false; // Determines if the Abyxa website is on the local server.
             Event? owevent = null; // The current overwatch event
-            ScreenshotMethods screenshotMethod = ScreenshotMethods.BitBlt;
+            ScreenshotMethod screenshotMethod = ScreenshotMethod.BitBlt;
 
             // Parse config file
             string[] config = null;
@@ -170,7 +170,7 @@ namespace ZombieBot
 
                             case "ScreenshotMethod":
                                 {
-                                    if (Enum.TryParse(lineSplit[1], out ScreenshotMethods set))
+                                    if (Enum.TryParse(lineSplit[1], out ScreenshotMethod set))
                                         screenshotMethod = set;
                                 }
                                 break;

--- a/ZombieBot/ZombieBot/ZombieBot.csproj
+++ b/ZombieBot/ZombieBot/ZombieBot.csproj
@@ -58,7 +58,7 @@
     <GenerateManifests>false</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
     <TargetZone>LocalIntranet</TargetZone>


### PR DESCRIPTION
It's quite likely that I'm doing it wrong, however I'm thinking there's a typo in the ZombieBot sample that references ScreenshotMethods instead of ScreenshotMethod. I also disabled manifest signing, since I... don't want to do that, and can't build the app without either getting a key / figuring out how to sign, or disabling signing.