### PR TITLE
Add support for decending and floating characters using baselines.

### DIFF
--- a/CustomGameLib/CustomGameLib.sln
+++ b/CustomGameLib/CustomGameLib.sln
@@ -14,8 +14,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.ActiveCfg = Release|Any CPU
-		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.Build.0 = Release|Any CPU
+		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.ActiveCfg = Final|Any CPU
+		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.Build.0 = Final|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/CustomGameLib/CustomGameLib.sln
+++ b/CustomGameLib/CustomGameLib.sln
@@ -14,8 +14,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.ActiveCfg = Final|Any CPU
-		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.Build.0 = Final|Any CPU
+		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.ActiveCfg = Release|Any CPU
+		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Final|Any CPU.Build.0 = Release|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7D6BA1B1-DA7B-4AEA-BA24-3657698F94AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/CustomGameLib/CustomGameLib/GetPlayerName.cs
+++ b/CustomGameLib/CustomGameLib/GetPlayerName.cs
@@ -37,17 +37,10 @@ namespace Deltin.CustomGameAutomation
             var pfc = new PrivateFontCollection();
             pfc.AddMemoryFont(fontData, fontBytes.Length);
             // Create the font with an EM size of 25.
-            FontFamily ff = pfc.Families[0];
-            Font font = new Font(ff, 25);
-
-            // Caluculate the baseline for the specified font
-            float lineSpace = ff.GetLineSpacing(font.Style); // The maximum distance between the top and bottom.
-            float ascent = ff.GetCellAscent(font.Style);     // The maximum height from the baseline.
-            float baseline = ascent / lineSpace;             // The position of the baseline relative to 1 em
+            Font font = new Font(pfc.Families[0], 25);
 
             Bitmap[] generated = new Bitmap[letters.Length]; // Stores the generated bitmaps.
-            int[] letterLengths = new int[letters.Length];   // Stores the last pixel on the X axis at the bottom of the letters.
-            int[] letterBaselines = new int[letters.Length]; // Stores the difference between the top of the cropped bitmap and the font's baseline.
+            int[] letterLengths = new int[letters.Length]; // Stores the last pixel on the X axis at the bottom of the letters.
 
             // Generate a bitmap of a picture of every letter using the font just loaded.
             // Store the bitmaps in the generated array.
@@ -60,8 +53,6 @@ namespace Deltin.CustomGameAutomation
                 Bitmap bmp = new Bitmap(size.Width, size.Height, PixelFormat.Format32bppArgb);
 
                 Graphics g = Graphics.FromImage(bmp);
-                // Store the initial baseline for the character relative to the graphic (this will be the same for every letter)
-                letterBaselines[l] = (int)(font.GetHeight(g) * baseline);
                 // Make the bitmap completely white
                 g.FillRectangle(Brushes.White, new Rectangle(0, 0, bmp.Width, bmp.Height));
                 // Set smoothing stuff
@@ -77,19 +68,15 @@ namespace Deltin.CustomGameAutomation
                 // Convert black and gray pixels to black and everything else white so it can be used as a markup.
                 for (int x = 0; x < bmp.Width; x++)
                     for (int y = 0; y < bmp.Height; y++)
-                        if (bmp.GetPixel(x, y).CompareColor(new int[] { 0, 0, 0 }, 35))
+                        if (bmp.GetPixel(x,y).CompareColor(new int[] { 0, 0, 0 }, 35))
                             bmp.SetPixel(x, y, Color.Black);
                         else
                             bmp.SetPixel(x, y, Color.White);
 
                 // The bitmap has a lot of extra area around it, crop the image around the letter.
-                Rectangle boundry = GetBounds(bmp);
-                Bitmap final = CropImage(bmp, boundry);
+                Bitmap final = CropImage(bmp, GetBounds(bmp));
                 bmp.Dispose();
                 // Don't use the bmp variable now!
-
-                // Adjust the baseline relative to the final bitmap
-                letterBaselines[l] -= boundry.Y;
 
                 // Get the pixels that are outside the letter.
                 // 'M' outside will get the pixels to the left and right of it,
@@ -165,7 +152,7 @@ namespace Deltin.CustomGameAutomation
             pfc.Dispose();
             Marshal.FreeCoTaskMem(fontData);
 
-            return new PlayerNameAlphabet(generated, letters, letterLengths, letterBaselines);
+            return new PlayerNameAlphabet(generated, letters, letterLengths);
         }
 
         private static byte[] GetFontResourceBytes(Assembly assembly, string fontResourceName)
@@ -361,7 +348,7 @@ namespace Deltin.CustomGameAutomation
                                         {
                                             // px and py is the Capture's relative letter position.
                                             int px = ax + lx;
-                                            int py = cy + ly + 2 - EnglishAlphabet.LetterBaselines[i];
+                                            int py = cy + ly + 2 - EnglishAlphabet.Markups[i].Height;
                                             bool pixelFilled = Capture.CompareColor(px, py, Colors.WHITE, letterCheckFade);
 
                                             // If a required pixel is missing, fail the letter.
@@ -582,16 +569,14 @@ namespace Deltin.CustomGameAutomation
         internal Bitmap[] Markups { get; private set; }
         internal string Letters { get; private set; }
         internal int[] LetterLengths { get; private set; }
-        internal int[] LetterBaselines { get; private set; }
         internal int Length { get; private set; }
 
-        internal PlayerNameAlphabet(Bitmap[] markups, string letters, int[] letterLengths, int[] letterBaselines)
+        internal PlayerNameAlphabet(Bitmap[] markups, string letters, int[] letterLengths)
         {
             Markups = markups;
             Letters = letters;
             Length = letters.Length;
             LetterLengths = letterLengths;
-            LetterBaselines = letterBaselines;
         }
 
         /// <summary>

--- a/CustomGameLib/CustomGameLib/GetPlayerName.cs
+++ b/CustomGameLib/CustomGameLib/GetPlayerName.cs
@@ -37,10 +37,17 @@ namespace Deltin.CustomGameAutomation
             var pfc = new PrivateFontCollection();
             pfc.AddMemoryFont(fontData, fontBytes.Length);
             // Create the font with an EM size of 25.
-            Font font = new Font(pfc.Families[0], 25);
+            FontFamily ff = pfc.Families[0];
+            Font font = new Font(ff, 25);
+
+            // Caluculate the baseline for the specified font
+            float lineSpace = ff.GetLineSpacing(font.Style); // The maximum distance between the top and bottom.
+            float ascent = ff.GetCellAscent(font.Style);     // The maximum height from the baseline.
+            float baseline = ascent / lineSpace;             // The position of the baseline relative to 1 em
 
             Bitmap[] generated = new Bitmap[letters.Length]; // Stores the generated bitmaps.
-            int[] letterLengths = new int[letters.Length]; // Stores the last pixel on the X axis at the bottom of the letters.
+            int[] letterLengths = new int[letters.Length];   // Stores the last pixel on the X axis at the bottom of the letters.
+            int[] letterBaselines = new int[letters.Length]; // Stores the difference between the top of the cropped bitmap and the font's baseline.
 
             // Generate a bitmap of a picture of every letter using the font just loaded.
             // Store the bitmaps in the generated array.
@@ -53,6 +60,8 @@ namespace Deltin.CustomGameAutomation
                 Bitmap bmp = new Bitmap(size.Width, size.Height, PixelFormat.Format32bppArgb);
 
                 Graphics g = Graphics.FromImage(bmp);
+                // Store the initial baseline for the character relative to the graphic (this will be the same for every letter)
+                letterBaselines[l] = (int)(font.GetHeight(g) * baseline);
                 // Make the bitmap completely white
                 g.FillRectangle(Brushes.White, new Rectangle(0, 0, bmp.Width, bmp.Height));
                 // Set smoothing stuff
@@ -68,15 +77,19 @@ namespace Deltin.CustomGameAutomation
                 // Convert black and gray pixels to black and everything else white so it can be used as a markup.
                 for (int x = 0; x < bmp.Width; x++)
                     for (int y = 0; y < bmp.Height; y++)
-                        if (bmp.GetPixel(x,y).CompareColor(new int[] { 0, 0, 0 }, 35))
+                        if (bmp.GetPixel(x, y).CompareColor(new int[] { 0, 0, 0 }, 35))
                             bmp.SetPixel(x, y, Color.Black);
                         else
                             bmp.SetPixel(x, y, Color.White);
 
                 // The bitmap has a lot of extra area around it, crop the image around the letter.
-                Bitmap final = CropImage(bmp, GetBounds(bmp));
+                Rectangle boundry = GetBounds(bmp);
+                Bitmap final = CropImage(bmp, boundry);
                 bmp.Dispose();
                 // Don't use the bmp variable now!
+
+                // Adjust the baseline relative to the final bitmap
+                letterBaselines[l] -= boundry.Y;
 
                 // Get the pixels that are outside the letter.
                 // 'M' outside will get the pixels to the left and right of it,
@@ -152,7 +165,7 @@ namespace Deltin.CustomGameAutomation
             pfc.Dispose();
             Marshal.FreeCoTaskMem(fontData);
 
-            return new PlayerNameAlphabet(generated, letters, letterLengths);
+            return new PlayerNameAlphabet(generated, letters, letterLengths, letterBaselines);
         }
 
         private static byte[] GetFontResourceBytes(Assembly assembly, string fontResourceName)
@@ -348,7 +361,7 @@ namespace Deltin.CustomGameAutomation
                                         {
                                             // px and py is the Capture's relative letter position.
                                             int px = ax + lx;
-                                            int py = cy + ly + 2 - EnglishAlphabet.Markups[i].Height;
+                                            int py = cy + ly + 2 - EnglishAlphabet.LetterBaselines[i];
                                             bool pixelFilled = Capture.CompareColor(px, py, Colors.WHITE, letterCheckFade);
 
                                             // If a required pixel is missing, fail the letter.
@@ -401,7 +414,7 @@ namespace Deltin.CustomGameAutomation
                                     float result = !isConnected ? 0 : match / total;
 
                                     // Add the result to the list.
-                                    results.Add(new PlayerNameLetterResult(EnglishAlphabet.Letters[i], result, (int)total, (int)match, EnglishAlphabet.Markups[i], EnglishAlphabet.LetterLengths[i]));
+                                    results.Add(new PlayerNameLetterResult(EnglishAlphabet.Letters[i], result, (int)total, (int)match, EnglishAlphabet.Markups[i], EnglishAlphabet.LetterLengths[i], EnglishAlphabet.LetterBaselines[i]));
                                     #region DEBUG
 #if DEBUG
                                     if (DebugMenu != null)
@@ -569,14 +582,16 @@ namespace Deltin.CustomGameAutomation
         internal Bitmap[] Markups { get; private set; }
         internal string Letters { get; private set; }
         internal int[] LetterLengths { get; private set; }
+        internal int[] LetterBaselines { get; private set; }
         internal int Length { get; private set; }
 
-        internal PlayerNameAlphabet(Bitmap[] markups, string letters, int[] letterLengths)
+        internal PlayerNameAlphabet(Bitmap[] markups, string letters, int[] letterLengths, int[] letterBaselines)
         {
             Markups = markups;
             Letters = letters;
             Length = letters.Length;
             LetterLengths = letterLengths;
+            LetterBaselines = letterBaselines;
         }
 
         /// <summary>
@@ -603,7 +618,7 @@ namespace Deltin.CustomGameAutomation
 
     internal class PlayerNameLetterResult
     {
-        public PlayerNameLetterResult(char letter, float result, int total, int match, Bitmap letterBmp, int letterLength)
+        public PlayerNameLetterResult(char letter, float result, int total, int match, Bitmap letterBmp, int letterLength, int letterBaseline)
         {
             Letter = letter;
             Result = result;
@@ -611,6 +626,7 @@ namespace Deltin.CustomGameAutomation
             Total = total;
             LetterBmp = letterBmp;
             LetterLength = letterLength;
+            LetterBaseline = letterBaseline;
         }
 
         public char Letter { get; private set; }
@@ -619,5 +635,6 @@ namespace Deltin.CustomGameAutomation
         public int Match { get; private set; }
         public Bitmap LetterBmp { get; private set; }
         public int LetterLength { get; private set; }
+        public int LetterBaseline { get; private set; }
     }
 }


### PR DESCRIPTION
To facilitate the detection of characters such as ", $, Д, etc.

The initial position to begin evaluating characters would instead be offset by the baseline (defined here as, the difference between the top of each character and the font's original baseline), instead of the height.

See usage on line 364. For characters such as A,B,C in BigNoodleToo, baseline is the same as their height.